### PR TITLE
Update eval & reset of DQN

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -17,6 +17,7 @@ parser.add_argument('--graphics_device_id', type=int, default=0, help='Graphics 
 parser.add_argument('--num_envs', default=512, type=int)
 parser.add_argument('--headless', action='store_true')
 parser.add_argument('--method', default='ppo', type=str)
+parser.add_argument('--train_time_step', type=int, default=10000)
 
 args = parser.parse_args()
 args.headless = True
@@ -31,5 +32,5 @@ elif args.method == 'ppo_d':
 elif args.method == 'dqn':
     policy = DQN(args)
 
-while True:
+for i in range(args.train_time_step):
     policy.run()


### PR DESCRIPTION
Hi, @lorenmt 

Sorry for not illustrating my idea well in #2. My idea is all about changing DQN's reset & evaluation implementation.

The originial DQN will be invoked by `run()` in a while-loop in `trainer.py`. However, the `reset()` invoked [here](https://github.com/lorenmt/minimal-isaac-gym/blob/106bdaf09c7da97c4e6e3cda1d747739f21e610d/dqn.py#L107)  can lead to following situation:
```mermaid
graph LR;
loop[While]-->run[run function]-->do[apply 1 step in multiple envs]-->push[collect data]-->reset[ENV RESET]-->update-->loop
```
In my humble opinion, the reset is too early given IsaacGym auto-resets the terminated environments ([ref](https://forums.developer.nvidia.com/t/clarifications-about-resetting-environments/183141)). This frequent reset prevents the agents from further continuing the task, thus we have many 1-step trajectories. The reset can also prevent us from generating full trajectories for evaluating. 

So I changed the implementation a bit:
```mermaid
graph LR;
loop[While]-->run[run function]-->do[apply 1 step in multiple envs]
push[collect data]-->update-->loop
do-->if[if one of envs terminated]--yes-->r[reset automatically]-->push
if--no-->push
```
However, since IsaacGym prohibits the creation of multiple environmets, I use the original (reset) environment for evaluation. Due to difficulty of extracting single environment out of parallel environments, I use the total accumulated reward with fixed-length trajectory as evaluation metric (during the fix-length experience, the env can be auto-reset and continue). 

Such modification prevents strange behvior in custom environment (e.g. [legged-gym](https://github.com/leggedrobotics/legged_gym) where the robot is trapped at the begining scene due to reset).

To justyfy the correctness of such modification, I ran the CartPole with/without `reset()`:
No-reset:
![dqn-no-reset](https://user-images.githubusercontent.com/72083122/223302852-6f56ce1a-23d8-40ca-a42a-78205a3cf81f.jpg)

reset:
![dqn-reset](https://user-images.githubusercontent.com/72083122/223302953-7553d6fe-4e0e-4b30-aab0-b7c1dd5f2068.jpg)

The highest acumulated reward is better for non-reset (~98 vs ~95). But I do fail to explain the osicillation.

Thank you for the discussion!